### PR TITLE
Make sure tag references current commit

### DIFF
--- a/.github/workflows/publish_image.yaml
+++ b/.github/workflows/publish_image.yaml
@@ -33,7 +33,7 @@ jobs:
           #!/bin/sh
           set -x
 
-          if ! GIT_TAG=$(git describe --abbrev=0); then
+          if ! GIT_TAG=$(git describe --abbrev=0 --exact-match); then
           printf "The commit to be built is not tagged correctly. It requires exactly one tag for the SemVer of the build. Locally, try running git tag -a <VERSION> && git push origin <VERSION>."
           exit 1
           fi


### PR DESCRIPTION
`git describe` get's most recent tag so you can end up in a scenario where you overwrite an image in artifact registry. This `--exact-match` option should ensure that we only deploy a tag that is associated with the most recent commit.